### PR TITLE
Formatters

### DIFF
--- a/hipcat/cli.py
+++ b/hipcat/cli.py
@@ -71,7 +71,9 @@ You must provide an 'access_token' in your configuration's 'hipchat' section.
 @click.version_option()
 @click.argument('room')
 @click.option('-m', '--message', help='A message to post. Uses STDIN if not provided.')
-def main(room, message):
+@click.option('-q', '--quote', help='Prefix the message with /quote for formatting.')
+@click.option('-c', '--code', help='Prefix the message with /code for formatting.')
+def main(room, message, quote, code):
     try:
         config = Config().load()
 
@@ -81,6 +83,11 @@ def main(room, message):
         )
         message = message or sys.stdin.read()
         if message:
+            if quote or code:
+                message = '{formatter} {message}'.format(
+                    formatter='/quote' if quote else '/code',
+                    message=message
+                )
             response = requests.post(
                 url,
                 headers={

--- a/hipcat/cli.py
+++ b/hipcat/cli.py
@@ -71,8 +71,8 @@ You must provide an 'access_token' in your configuration's 'hipchat' section.
 @click.version_option()
 @click.argument('room')
 @click.option('-m', '--message', help='A message to post. Uses STDIN if not provided.')
-@click.option('-q', '--quote', help='Prefix the message with /quote for formatting.')
-@click.option('-c', '--code', help='Prefix the message with /code for formatting.')
+@click.option('-q', '--quote', help='Prefix the message with /quote for formatting.', is_flag=True)
+@click.option('-c', '--code', help='Prefix the message with /code for formatting.', is_flag=True)
 def main(room, message, quote, code):
     try:
         config = Config().load()


### PR DESCRIPTION
I've added the options to prefix a message with /quote or /code.

These can be invoked with the -q (--quote) and -c (--code) params, and are set as flags to indicate they take no arguments.
