### PR TITLE
Add support for notification API along with notification color, sender etc.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,5 @@
 # Contributors
 
-* Mark Smith ([@judy2k](https://www.github.com/judy2k/))
+* Mark Smith ([@judy2k](https://www.github.com/judy2k))
 * [@Krylik](https://github.com/Krylik)
+* Evgeny Chernyavskiy ([@echernyavskiy](https://github.com/echernyavskiy))

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,23 @@ If the text you are sending to HipChat is formatted, use the ``-q`` flag
 to prefix with ``/quote``, and if it should be syntax-highlighted code,
 use the ``-c`` flag to prefix with ``/code``.
 
+The message you are sending may also be treated as a
+[room notification](https://www.hipchat.com/docs/apiv2/method/send_room_notification)
+via the ``--notification`` flag. The following additional options and flags
+are then recognized by **hipcat**:
+
+- ``--color`` to specify background color for the message. Valid values:
+yellow, green, red, purple, gray, random. Defaults to *yellow*.
+- ``--sender`` to specify a label to be shown in addition to the sender's name.
+Defaults to *hipcat* if ``--notify`` (see below) is specified as well.
+- ``--notify`` to ensure this message triggers a user notification.
+
+.. code:: bash
+
+    # Send a message "Message" with a purple background, from "BOT" and with a user notification.
+    hipcat 'Notifications' --notification --notify -m "Message" --color=purple --sender="BOT"
+
+
 Contributing to hipcat
 ----------------------
 


### PR DESCRIPTION
This changeset adds support for the [room notification](https://www.hipchat.com/docs/apiv2/method/send_room_notification) API:
- it is now possible to force a message to be a room notification via the `--notification` flag;
- color, sender/from and whether to trigger a user notification may be specified via `--color`, `--sender` and `--notify` respectively.
